### PR TITLE
feat(origin): add a middleware to validate origin requests

### DIFF
--- a/origin_verifier.go
+++ b/origin_verifier.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+const OriginVerifyHeaderName = "X-Origin-Verify"
+
+// OriginVerifierConfig used to configure the origin authentication middleware
+type OriginVerifierConfig struct {
+	// Token used to validate requests coming include the required header
+	Token string
+
+	// Skipper defines a function to skip middleware.
+	Skipper middleware.Skipper
+}
+
+// OriginVerifierWithConfig returns a middleware which verifies requests include a `X-Origin-Verify` header
+// containing the token configured, requests which fail will be rejected with a 400 bad request status code.
+//
+// This solution is based on a pattern presented in https://aws.amazon.com/blogs/networking-and-content-delivery/restricting-access-http-api-gateway-lambda-authorizer/
+// and uses the same header name.
+func OriginVerifierWithConfig(config OriginVerifierConfig) echo.MiddlewareFunc {
+	if config.Skipper == nil {
+		config.Skipper = middleware.DefaultSkipper
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) (err error) {
+			if config.Skipper(c) {
+				return next(c)
+			}
+
+			headerToken := c.Request().Header.Get(OriginVerifyHeaderName)
+
+			if subtle.ConstantTimeCompare([]byte(config.Token), []byte(headerToken)) != 1 {
+				return c.String(http.StatusBadRequest, "Bad Request")
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/origin_verifier_test.go
+++ b/origin_verifier_test.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOriginVerifierWithConfig(t *testing.T) {
+	type args struct {
+		config OriginVerifierConfig
+	}
+	tests := []struct {
+		name       string
+		args       args
+		headers    map[string]string
+		wantStatus int
+	}{
+		{
+			name:       "should accept request with valid verify token",
+			args:       args{config: OriginVerifierConfig{Token: "test"}},
+			headers:    map[string]string{"X-Origin-Verify": "test"},
+			wantStatus: 200,
+		},
+		{
+			name:       "should reject request with no valid verify token",
+			args:       args{config: OriginVerifierConfig{Token: "test"}},
+			headers:    map[string]string{},
+			wantStatus: 400,
+		},
+		{
+			name:       "should reject request with an invalid verify token",
+			args:       args{config: OriginVerifierConfig{Token: "test"}},
+			headers:    map[string]string{"X-Origin-Verify": "nottest"},
+			wantStatus: 400,
+		},
+		{
+			name:       "should skip request which match the skipper",
+			args:       args{config: OriginVerifierConfig{Token: "test", Skipper: func(c echo.Context) bool { return true }}},
+			headers:    map[string]string{"X-Origin-Verify": "nottest"},
+			wantStatus: 200,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+
+			e := echo.New()
+
+			req := httptest.NewRequest(http.MethodGet, "/login", nil)
+
+			for k, v := range tt.headers {
+				req.Header.Add(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			h := OriginVerifierWithConfig(tt.args.config)(func(c echo.Context) error {
+				return c.NoContent(200)
+			})
+
+			err := h(c)
+			assert.NoError(err)
+			assert.Equal(tt.wantStatus, rec.Result().StatusCode)
+		})
+	}
+}


### PR DESCRIPTION
This solution is based on a pattern presented in https://aws.amazon.com/blogs/networking-and-content-delivery/restricting-access-http-api-gateway-lambda-authorizer/ and uses the same header name.
